### PR TITLE
Remove unsubscribe dialog

### DIFF
--- a/services/api/api/blueprint/twilio/route.py
+++ b/services/api/api/blueprint/twilio/route.py
@@ -46,7 +46,7 @@ def unsubscribe():
     # unsubscribe from alerts
     twilio_bot.unsubscribe(request.form)
 
-    return twilio_bot.say_goodbye()
+    return {}
 
 
 @blueprint.route('/bot/fallback', methods=['POST'])

--- a/services/api/lib/twilio/bot.py
+++ b/services/api/lib/twilio/bot.py
@@ -127,18 +127,6 @@ class TwilioBot:
         phone_number = form_post['UserIdentifier']
         alerts_repo.delete_alert(phone_number)
 
-    def say_goodbye(self):
-        return {
-            'actions': [
-                {
-                    'say': (
-                        f"Thanks for letting me know. I'll stop sending reminders."
-                        f"{message_footer}"
-                    )
-                }
-            ]
-        }
-
     def say_fallback(self):
         return {
             "actions": [


### PR DESCRIPTION
- Twilio handles this dialog as part of SMS regulatory compliance.